### PR TITLE
feat: add email confirmation dialog on login screen

### DIFF
--- a/petJournal/app/src/main/java/com/soujunior/petjournal/ui/screens_app/account_manager/loginScreen/LoginScreen.kt
+++ b/petJournal/app/src/main/java/com/soujunior/petjournal/ui/screens_app/account_manager/loginScreen/LoginScreen.kt
@@ -3,17 +3,26 @@ package com.soujunior.petjournal.ui.screens_app.account_manager.loginScreen
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import com.soujunior.petjournal.R
+import com.soujunior.petjournal.ui.screens_app.account_manager.loginScreen.components.AccountConfirmationDialog
 import com.soujunior.petjournal.ui.screens_app.account_manager.loginScreen.components.Screen
 import com.soujunior.petjournal.ui.util.ValidationEvent
 import org.koin.androidx.compose.getViewModel
+import androidx.compose.runtime.*
 
 @Composable
 fun LoginScreen(navController: NavController) {
     val viewModel: LoginViewModel = getViewModel()
     val context = LocalContext.current
+    var showDialog by remember { mutableStateOf(false) }
+
+    if (showDialog) {
+        AccountConfirmationDialog(onDismiss = { showDialog = false })
+    }
 
     LaunchedEffect(key1 = context) {
         viewModel.validationEvents.collect { event ->
@@ -24,11 +33,29 @@ fun LoginScreen(navController: NavController) {
                 }
 
                 is ValidationEvent.Failed -> {
-                    Toast.makeText(
-                        context,
-                        R.string.incorrect_username_password,
-                        Toast.LENGTH_LONG
-                    ).show()
+                    if (event == ValidationEvent.Failed && viewModel.message.value == context.getString(
+                            R.string.email_are_not_confirmed
+                        )
+                    ) {
+                        showDialog = true
+                    } else if (event == ValidationEvent.Failed && viewModel.message.value == context.getString(
+                            R.string.user_not_found) || viewModel.message.value == context.getString(
+                            R.string.Unauthorized
+                        )
+                    ) {
+                        Toast.makeText(
+                            context,
+                            R.string.incorrect_username_password,
+                            Toast.LENGTH_LONG
+                        ).show()
+                    } else {
+                        Toast.makeText(
+                            context,
+                            context.getString(R.string.something_went_wrong_try_again_later),
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+
                 }
             }
         }

--- a/petJournal/app/src/main/java/com/soujunior/petjournal/ui/screens_app/account_manager/loginScreen/components/AccountConfirmationDialog.kt
+++ b/petJournal/app/src/main/java/com/soujunior/petjournal/ui/screens_app/account_manager/loginScreen/components/AccountConfirmationDialog.kt
@@ -1,0 +1,85 @@
+package com.soujunior.petjournal.ui.screens_app.account_manager.loginScreen.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.Dialog
+import com.soujunior.petjournal.R
+import com.soujunior.petjournal.ui.theme.ColorCustom
+import ir.kaaveh.sdpcompose.sdp
+import ir.kaaveh.sdpcompose.ssp
+
+@Composable
+fun AccountConfirmationDialog(onDismiss: () -> Unit) {
+    Dialog(onDismissRequest = { onDismiss() }) {
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            color = ColorCustom.link_200,
+            tonalElevation = 8.sdp
+        ) {
+
+            Column(
+                modifier = Modifier
+                    .padding(16.sdp)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+
+                Text(
+                    text = stringResource(R.string.title_dialog_Email_Confirmation),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontSize = 16.ssp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(bottom = 8.sdp)
+                )
+
+                Text(
+                    text = stringResource(R.string.txt_your_petJournal_account_is_almost_ready_to_activate_it_please_confirm_your_email),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontSize = 10.ssp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(bottom = 16.sdp)
+
+                )
+
+                Text(
+                    text = stringResource(R.string.txt_If_you_have_not_registered_with_petJournal_recently_please_ignore_this_email),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontSize = 10.ssp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(bottom = 16.sdp)
+                )
+                Text(
+                    text = stringResource(R.string.txt_petJournal_team),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontSize = 10.ssp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.padding(bottom = 16.sdp)
+                )
+
+                TextButton(
+                    onClick = { onDismiss() },
+                    modifier = Modifier.align(Alignment.End),
+                ) {
+                    Text(text = stringResource(R.string.txt_btn_understood), fontSize = 10.ssp, color = MaterialTheme.colorScheme.primary)
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewSimpleDialog() {
+    AccountConfirmationDialog(onDismiss = {})
+}

--- a/petJournal/app/src/main/java/com/soujunior/petjournal/ui/screens_app/account_manager/loginScreen/components/Screen.kt
+++ b/petJournal/app/src/main/java/com/soujunior/petjournal/ui/screens_app/account_manager/loginScreen/components/Screen.kt
@@ -41,7 +41,7 @@ fun getLoginViewModelForPreview(): LoginViewModel {
     }
 }
 @Composable
-fun Screen(navController: NavController, /*viewModel: LoginViewModel*/) {
+fun Screen(navController: NavController) {
     val viewModel = getLoginViewModelForPreview()
     val systemUiController = rememberSystemUiController()
 

--- a/petJournal/app/src/main/java/com/soujunior/petjournal/ui/theme/Color.kt
+++ b/petJournal/app/src/main/java/com/soujunior/petjournal/ui/theme/Color.kt
@@ -74,6 +74,7 @@ object ColorGrid {
 
 object ColorCustom {
     val dark_texts_variant = Color(0xFF686767)
+    val link_200 = Color(0xFFA5EFFB)
 }
 
 

--- a/petJournal/app/src/main/res/values/strings.xml
+++ b/petJournal/app/src/main/res/values/strings.xml
@@ -98,5 +98,14 @@
     <string name="txt_enter_the_6_digit_verification_code_sent_to_your_email_in_the_field_below">2. Insira no campo abaixo o código de verificação de 6 dígitos enviado para o seu email:</string>
     <string name="txt_resend_code">Reenviar código?</string>
     <string name="txt_tip_If_you_dont_find_the_email_in_your_inbox_check_your_spam_folder">Dica:  Se não localizar o e-mail em sua caixa de entrada, verifique a pasta de spam.</string>
+    <string name="title_dialog_Email_Confirmation">Confirmação do E-mail</string>
+    <string name="txt_your_petJournal_account_is_almost_ready_to_activate_it_please_confirm_your_email">Sua conta PetJournal está quase pronta. Para ativá-la, por favor confirme seu email.</string>
+    <string name="txt_If_you_have_not_registered_with_petJournal_recently_please_ignore_this_email">Se você não se cadastrou na PetJournal recentemente, por favor ignore este email.</string>
+    <string name="txt_petJournal_team">Equipe PetJournal</string>
+    <string name="txt_btn_understood">Entendi</string>
+    <string name="email_are_not_confirmed">401 -> your email are not confirmed></string>
+    <string name="user_not_found">401 -> Not found: User not found</string>
+    <string name="Unauthorized">401 -> Unauthorized</string>
+    <string name="something_went_wrong_try_again_later">Algo deu errado...Tente de novo mais tarde!</string>
 
 </resources>

--- a/petJournal/app/src/main/res/values/strings.xml
+++ b/petJournal/app/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="txt_If_you_have_not_registered_with_petJournal_recently_please_ignore_this_email">Se você não se cadastrou na PetJournal recentemente, por favor ignore este email.</string>
     <string name="txt_petJournal_team">Equipe PetJournal</string>
     <string name="txt_btn_understood">Entendi</string>
-    <string name="email_are_not_confirmed">401 -> your email are not confirmed></string>
+    <string name="email_are_not_confirmed">401 -> your email are not confirmed</string>
     <string name="user_not_found">401 -> Not found: User not found</string>
     <string name="Unauthorized">401 -> Unauthorized</string>
     <string name="something_went_wrong_try_again_later">Algo deu errado...Tente de novo mais tarde!</string>


### PR DESCRIPTION
### Adicionado dialog na tela de login para o caso do usuário não ter confirmado o email ainda

- Criado Dialog
- Tratamento das mensagens do backend para os casos de login
